### PR TITLE
Default to opening docs in same window/tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 							<ul>
 								<li class="current"><a href="index.html">Home</a></li>
 								<li><a href="install.html">Install</a></li>
-								<li><a href="http://docs.glueviz.org" target="_blank">Documentation</a></li>
+								<li><a href="http://docs.glueviz.org">Documentation</a></li>
 								<li><a href="team.html">Team</a></li>
 								<li><a href="get_involved.html">Get involved</a></li>
 								<li><a href="plugins.html">Plugins</a></li>


### PR DESCRIPTION
the `target='_blank'` link defaults to opening the documentation in a new tab.  I don't like this or see any reason for it, but please feel free to ignore this if there is a _good_ reason.