### PR TITLE
Add link to airplane demo video

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,17 @@
 								</div>
 							</section>
 						</div>
+						<div class="row">
+							<section class="6u 12u(narrower)">
+								<div class="box post">
+									<a href="https://www.youtube.com/watch?v=L1Fb9R4q5lA" class="image left"><img src="images/video_airplanes.jpg" alt="" /></a>
+									<div class="inner">
+										<h3>Video: <a href="https://www.youtube.com/watch?v=L1Fb9R4q5lA">Learn to fly glue, fast</a></h3>
+										<p>A 6-minute tutorial demonstrating many core features of glue. Go <a href="https://www.gluesolutions.io/airplanes-demo">here</a> for the full demo, including all necessary files.</a></p>
+									</div>
+								</div>
+							</section>
+						</div>
 					</div>
 
 				</section>


### PR DESCRIPTION
Per a request from Alyssa, this PR adds the airplane demo video to the set of video links on the main page.