### PR TITLE
Update packages description

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -66,12 +66,13 @@
 
 <h3>Main glue packages</h3>
 
-<p>There are two main glue packages - <a href="https://github.com/glue-viz/glue"
-target="_blank">glue-core</a>, which defines the core infrastructure for glue as
-well as provides the Qt-based desktop application, and <a
-href="https://github.com/glue-viz/glue-jupyter"
-target="_blank">glue-jupyter</a>, which provides a Jupyter-based glue
-application.</p>
+<p>There are three main glue packages. The most important of these is
+<a href="https://github.com/glue-viz/glue" target="_blank">glue-core</a>,
+which defines the core infrastructure for glue. There are also two main
+frontend packages: <a href="https://github.com/glue-viz/glue-qt" target="_blank">glue-qt</a>,
+which provides a Qt-based glue application, and
+<a href="https://github.com/glue-viz/glue-jupyter" target="_blank">glue-jupyter</a>,
+which provides a Jupyter-based glue application.</p>
 
 <h3>Glue plugins</h3>
 
@@ -90,6 +91,7 @@ data on how to install and use:</p>
 <li><a href="https://github.com/glue-viz/glue-h5part" target="_blank">glue-h5part</a>: Experimental plugin to deal with h5part data</li>
 <li><a href="https://github.com/glue-viz/glue-medical" target="_blank">glue-medical</a>: Experimental Glue medical plugin</li>
 <li><a href="https://github.com/glue-viz/glue-openspace" target="_blank">glue-openspace</a>: Experimental <a href="https://www.openspaceproject.com/">OpenSpace</a> plugin</a></li>
+<li><a href="https://github.com/glue-viz/glue-plotly" target="_blank">glue-plotly</a>: Experimental <a href="https://plotly.com/">Plotly</a> plugin</li>
 <li><a href="https://github.com/glue-viz/glue-samp" target="_blank">glue-samp</a>: Experimental <a href="http://www.ivoa.net/documents/SAMP/">SAMP</a> plugin</a></li>
 <li><a href="https://github.com/glue-viz/glue-specviz" target="_blank">glue-specviz</a>: Experimental plugin to wrap <a href="https://specviz.readthedocs.io/en/stable/">specviz</a> spectroscopy tool</li>
 <li><a href="https://github.com/glue-viz/glue-vispy-viewers">glue-vispy-viewers</a>: Plugin for 3D viewers using <a href="http://vispy.org/">VisPy</a></li>

--- a/plugins.html
+++ b/plugins.html
@@ -68,9 +68,9 @@
 
 <p>There are three main glue packages. The most important of these is
 <a href="https://github.com/glue-viz/glue" target="_blank">glue-core</a>,
-which defines the core infrastructure for glue. There are also two main
+which defines the core infrastructure for glue. There are also two primary
 frontend packages: <a href="https://github.com/glue-viz/glue-qt" target="_blank">glue-qt</a>,
-which provides a Qt-based glue application, and
+which provides a Qt-based desktop application, and
 <a href="https://github.com/glue-viz/glue-jupyter" target="_blank">glue-jupyter</a>,
 which provides a Jupyter-based glue application.</p>
 


### PR DESCRIPTION
This PR makes a couple of updates to the packages page:
* Update the description of the main glue packages to reflect the fact that we've split the Qt application code out into `glue-qt`
* Add `glue-plotly` to the list of glue packages - we include it in the distributed DMGs so it should probably get mentioned here